### PR TITLE
Feature/dont remember passkeys

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,11 +16,10 @@ When you've installed and configured the package, log into the backffice, press 
 - Passwordless login to the umbraco backoffice.
 - Register multiple Authenticators to your user
 - Platform (Windows hello etc) And Cross Platform (Android/Iphone via passkeys, YubiKey etc) Authenticators supported.
+- Forgot password registers new authenticator
 
 ## Planned features
 
-- Completely disable password login
-- Forgot password registers new authenticator
 - Passwordless login for members.
 - Better configuration for consumers
 - Umbraco 9 Support. This might take longer as the .net 5 version of fido2.net lib is quite outdated.
@@ -28,7 +27,6 @@ When you've installed and configured the package, log into the backffice, press 
 
 ### Known issues
 - The "Remember last authenticator" checkbox works poorly with passkeys, not sure if it can be helped?
-- The CSS styling could need a loving hand
 
 ## Install
 Use nuget to install Our.Umbraco.Passless

--- a/src/Our.Umbraco.Passless/Assertions/Endpoints/MakeAssertionController.cs
+++ b/src/Our.Umbraco.Passless/Assertions/Endpoints/MakeAssertionController.cs
@@ -83,6 +83,7 @@ namespace Our.Umbraco.Passless.Assertions.Endpoints
                     {
                         RedirectUrl = backOfficePath,
                         Status = res.Status,
+                        IsPasskey = creds.IsPasskey,
                         CredentialId = Convert.ToBase64String(res.CredentialId)
                     });
             }

--- a/src/Our.Umbraco.Passless/Credentials/Endpoints/CredentialsOptionsController.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Endpoints/CredentialsOptionsController.cs
@@ -67,7 +67,7 @@ public class CredentialsOptionsController : UmbracoAuthorizedController
             UserVerificationMethod = true,
         };
 
-        var options = fido2.RequestNewCredential(user, existingKeys, authenticatorSelection, AttestationConveyancePreference.None, exts);
+        var options = fido2.RequestNewCredential(user, existingKeys, authenticatorSelection, AttestationConveyancePreference.Direct, exts);
 
         // 4. Temporarily store options, session/in-memory cache/redis/db
         HttpContext.Session.SetString("fido2.attestationOptions", options.ToJson());

--- a/src/Our.Umbraco.Passless/Credentials/Endpoints/MakeCredentialsController.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Endpoints/MakeCredentialsController.cs
@@ -63,8 +63,9 @@ public class MakeCredentialsController : UmbracoAuthorizedController
                 success.Result.User.Id,
                 success.Result.Counter,
                 success.Result.CredType,
-                DateTime.Now,
-                success.Result.Aaguid
+                DateTime.UtcNow,
+                success.Result.Aaguid,
+                success.Result.CredType.Equals("none", StringComparison.Ordinal) //TODO: This is not 100% correct. Local testing shows that if we request attestation and signin with passkeys, none is returned. There might be other cross-platform authenticators which return none?
             ));
 
 

--- a/src/Our.Umbraco.Passless/Credentials/Endpoints/MakeCredentialsController.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Endpoints/MakeCredentialsController.cs
@@ -54,6 +54,7 @@ public class MakeCredentialsController : UmbracoAuthorizedController
                 throw new InvalidOperationException("Unexpected, credentials result is null");
             }
 
+            var isPasskey = success.Result.CredType.Equals("none", StringComparison.Ordinal); //TODO: This is not 100% correct. Local testing shows that if we request attestation and signin with passkeys, none is returned. There might be other cross-platform authenticators which return none?
             // 4. Add the credentials to the user. in the database.
             await credentialsService.AddCredential(new FidoCredentialModel(
                 alias,
@@ -65,11 +66,15 @@ public class MakeCredentialsController : UmbracoAuthorizedController
                 success.Result.CredType,
                 DateTime.UtcNow,
                 success.Result.Aaguid,
-                success.Result.CredType.Equals("none", StringComparison.Ordinal) //TODO: This is not 100% correct. Local testing shows that if we request attestation and signin with passkeys, none is returned. There might be other cross-platform authenticators which return none?
+                isPasskey
             ));
 
 
-            return new JsonResult(success);
+            return new JsonResult(new
+            {
+                CredentialId = success.Result.CredentialId,
+                IsPassKey = isPasskey
+            });
         }
         catch (Exception ex)
         {

--- a/src/Our.Umbraco.Passless/Credentials/Models/FidoCredentialModel.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Models/FidoCredentialModel.cs
@@ -4,7 +4,16 @@ namespace Our.Umbraco.Passless.Credentials.Models;
 
 public class FidoCredentialModel
 {
-    public FidoCredentialModel(string alias, byte[] userId, PublicKeyCredentialDescriptor descriptor, byte[] publicKey, byte[] userHandle, uint signatureCounter, string credType, DateTime regDate, Guid aaGuid)
+    public FidoCredentialModel(string alias,
+                               byte[] userId,
+                               PublicKeyCredentialDescriptor descriptor,
+                               byte[] publicKey,
+                               byte[] userHandle,
+                               uint signatureCounter,
+                               string credType,
+                               DateTime regDate,
+                               Guid aaGuid,
+                               bool isPasskey)
     {
         Alias = alias;
         UserId = userId;
@@ -15,6 +24,7 @@ public class FidoCredentialModel
         CredType = credType;
         RegDate = regDate;
         AaGuid = aaGuid;
+        IsPasskey = isPasskey;
     }
 
     public string Alias { get; set; }
@@ -26,5 +36,5 @@ public class FidoCredentialModel
     public string CredType { get; set; }
     public DateTime RegDate { get; set; }
     public Guid AaGuid { get; set; }
-
+    public bool IsPasskey { get; set; }
 }

--- a/src/Our.Umbraco.Passless/Credentials/Persistence/FidoCredentialEntity.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Persistence/FidoCredentialEntity.cs
@@ -28,5 +28,7 @@ namespace Our.Umbraco.Passless.Credentials.Persistence
         public DateTime RegDate { get; set; }
         [Column("aaGuid")]
         public Guid AaGuid { get; set; }
+        [Column("isPasskey")]
+        public bool IsPassKey { get; set; }
     }
 }

--- a/src/Our.Umbraco.Passless/Credentials/Persistence/Migrations/AddFidoCredentialEntity.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Persistence/Migrations/AddFidoCredentialEntity.cs
@@ -1,39 +1,39 @@
 ﻿using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Extensions;
 
-namespace Our.Umbraco.Passless.Credentials.Persistence.Migrations
+namespace Our.Umbraco.Passless.Credentials.Persistence.Migrations;
+
+public class AddFidoCredentialEntity : MigrationBase
 {
-    public class AddFidoCredentialEntity : MigrationBase
+    public AddFidoCredentialEntity(IMigrationContext context) : base(context)
     {
-        public AddFidoCredentialEntity(IMigrationContext context) : base(context)
+    }
+
+    protected override void Migrate()
+    {
+        if (TableExists("fidoCredential"))
         {
+            Logger.LogDebug("The fido Credential table already exists, skipping");
+            return;
         }
 
-        protected override void Migrate()
+        Create.Table<FidoCredentialEntity>()
+            .Do();
+
+        if (DatabaseType is NPoco.DatabaseTypes.SQLiteDatabaseType)
         {
-            if (TableExists("fidoCredential"))
-            {
-                Logger.LogDebug("The fido Credential table already exists, skipping");
-                return;
-            }
+            return; // SQLite doesnt support the clustered index. So lets return. 
+        }
 
-            Create.Table<FidoCredentialEntity>()
-                .Do();
-
-            if (DatabaseType is NPoco.DatabaseTypes.SQLiteDatabaseType)
-            {
-                return; // SQLite doesnt support the clustered index. So lets return. 
-            }
-
-            //Since we're having a Guid as PK lets setup the clustered index https://stackoverflow.com/questions/11938044/what-are-the-best-practices-for-using-a-guid-as-a-primary-key-specifically-rega
-            var sql = Sql(
-                @"ALTER TABLE fidoCredential
+        //Since we're having a Guid as PK lets setup the clustered index https://stackoverflow.com/questions/11938044/what-are-the-best-practices-for-using-a-guid-as-a-primary-key-specifically-rega
+        var sql = Sql(
+            @"ALTER TABLE fidoCredential
 ADD
     rowkey int identity(1,1);
 CREATE UNIQUE CLUSTERED INDEX CIX_RowKey on fidoCredential(rowkey);
 ");
 
-            Database.Execute(sql);
-        }
+        Database.Execute(sql);
     }
 }

--- a/src/Our.Umbraco.Passless/Credentials/Persistence/Migrations/AddIsPassKeyToFidoCredential.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Persistence/Migrations/AddIsPassKeyToFidoCredential.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace Our.Umbraco.Passless.Credentials.Persistence.Migrations;
+
+public class AddIsPassKeyToFidoCredential : MigrationBase
+{
+    public AddIsPassKeyToFidoCredential(IMigrationContext context) : base(context)
+    {
+    }
+
+    protected override void Migrate()
+    {
+        if (ColumnExists("fidoCredential", "isPasskey"))
+        {
+            Logger.LogDebug("The fido Credential table already exists, skipping");
+            return;
+        }
+
+        Create.Column("isPasskey")
+            .OnTable("fidoCredential")
+            .AsBoolean()
+            .WithDefaultValue(false)
+            .Do();
+    }
+}

--- a/src/Our.Umbraco.Passless/Credentials/Persistence/MigrationsComponent.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Persistence/MigrationsComponent.cs
@@ -38,6 +38,9 @@ public class MigrationsComponent : IComponent
         migrationPlan.From(string.Empty)
             .To<AddFidoCredentialEntity>("fidocredetials-db");
 
+        migrationPlan.From("fidocredetials-db")
+            .To<AddIsPassKeyToFidoCredential>(nameof(AddIsPassKeyToFidoCredential));
+
         var upgrader = new Upgrader(migrationPlan);
 
         upgrader.Execute(migrationPlanExecutor, scopeProvider, keyValueService);

--- a/src/Our.Umbraco.Passless/Credentials/Services/CredentialsService.cs
+++ b/src/Our.Umbraco.Passless/Credentials/Services/CredentialsService.cs
@@ -86,7 +86,8 @@ public class CredentialsService : ICredentialsService
             Convert.ToUInt32(entity.SignatureCounter),
             entity.CredType,
             entity.RegDate,
-            entity.AaGuid
+            entity.AaGuid,
+            entity.IsPassKey
         );
     }
 

--- a/src/Our.Umbraco.Passless/Our.Umbraco.Passless.csproj
+++ b/src/Our.Umbraco.Passless/Our.Umbraco.Passless.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.0.2</Version>
+    <Version>0.0.4</Version>
     <Authors>Aleksander Fjellvang</Authors>
     <Description>Passworless login for Umbraco 10+ using FIDO and WebauthN</Description>
     <PackageProjectUrl>https://github.com/Fjellvang/Our.Umbraco.Passless</PackageProjectUrl>

--- a/src/Our.Umbraco.Passless/Our.Umbraco.Passless.csproj
+++ b/src/Our.Umbraco.Passless/Our.Umbraco.Passless.csproj
@@ -17,10 +17,8 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageReleaseNotes>
-      - Enabled LostAuthenticator step if SMTP is configured
-      - Enabled DenyLocalLogin
-      - Added Some error messages on failed login
-      - Fixed some CSS
+      - Enforced Attestation, to detect passkeys signins.
+      - On passkey sign ins don't persist credential IDs due to windows hello bug
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/customlogin.controller.ts
+++ b/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/customlogin.controller.ts
@@ -159,7 +159,9 @@ export class CustomLoginController {
         this.$http.post<AssertionResponse>(this.makeAssertionEndpoint, JSON.stringify(data))
             .then(success => {
                 const response = success.data;
-                localStorage.setItem("lastCredentials", response.credentialId);
+                if (response.isPassKey === false) {
+                    localStorage.setItem("lastCredentials", response.credentialId);
+                }
                 this.$window.location.href = response.redirectUrl
             }, () => {
                 console.log("Error doing assertion");

--- a/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/overlays/credentials.controller.ts
+++ b/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/overlays/credentials.controller.ts
@@ -83,7 +83,7 @@ export class CredentialsController {
     public submitRegisterPasslessForm(): void {
         this.registrationService.registerNewCredentials(this.registrationAlias)
             .then(success => {
-                this.onKeyRegisteredWithServer(success.data.result)
+                this.onKeyRegisteredWithServer(success.data)
             }, failure => {
                 this.notificationsService.error(failure);
             })
@@ -96,7 +96,9 @@ export class CredentialsController {
     }
     
     private onKeyRegisteredWithServer(credentials: AttestationVerificationSuccess): void {
-        localStorage.setItem("lastCredentials", (credentials.credentialId))
+        if (credentials.isPassKey === false) {
+            localStorage.setItem("lastCredentials", (credentials.credentialId));
+        }
         this.notificationsService.success(`Successfully added new credentials with the alias ${this.registrationAlias}`);
         this.state = 'ready';
         this.getCredentials();

--- a/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/services/credentialsService.ts
+++ b/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/services/credentialsService.ts
@@ -1,5 +1,5 @@
 ﻿import { coerceToArrayBuffer, coerceToBase64Url } from "../helpers";
-import { CredentialMakeResult, UserCredentials } from "../types";
+import { AttestationVerificationSuccess, UserCredentials } from "../types";
 
 // TODO: define a type for this variable
 declare const Umbraco: any;
@@ -31,7 +31,7 @@ export class CredentialsService {
         return this.$http.get<UserCredentials>(this.getCredentialsEndpoint);
     }
 
-    public registerNewCredentials(registrationAlias: string): angular.IHttpPromise<CredentialMakeResult>  {
+    public registerNewCredentials(registrationAlias: string): angular.IHttpPromise<AttestationVerificationSuccess>  {
         return this.$http.get<PublicKeyCredentialCreationOptions>(`${this.credentialsOptionsEndpoint}`)
             .then(success => {
                 const makeCredentialsOptions = success.data;
@@ -43,7 +43,7 @@ export class CredentialsService {
             });
     }
 
-    private handleUserCredentials(makeCredentialOptions: PublicKeyCredentialCreationOptions, registrationAlias: string): angular.IHttpPromise<CredentialMakeResult>  {
+    private handleUserCredentials(makeCredentialOptions: PublicKeyCredentialCreationOptions, registrationAlias: string): angular.IHttpPromise<AttestationVerificationSuccess>  {
 
         // Turn the challenge back into the accepted format of padded base64
         makeCredentialOptions.challenge = coerceToArrayBuffer(makeCredentialOptions.challenge);
@@ -66,7 +66,7 @@ export class CredentialsService {
         });
     }
 
-    private prepareNewCredentials(newCredentials: PublicKeyCredential, registrationAlias: string): angular.IHttpPromise<CredentialMakeResult> {
+    private prepareNewCredentials(newCredentials: PublicKeyCredential, registrationAlias: string): angular.IHttpPromise<AttestationVerificationSuccess> {
         // Move data into Arrays incase it is super long
         const attestationObject = new Uint8Array((newCredentials.response as AuthenticatorAttestationResponse).attestationObject);
         const clientDataJSON = new Uint8Array(newCredentials.response.clientDataJSON);
@@ -88,9 +88,9 @@ export class CredentialsService {
         return this.registerCredentialWithServer(data, registrationAlias);
     }
 
-    private registerCredentialWithServer(formData: any, registrationAlias: string): angular.IHttpPromise<CredentialMakeResult> {
+    private registerCredentialWithServer(formData: any, registrationAlias: string): angular.IHttpPromise<AttestationVerificationSuccess> {
         const body = JSON.stringify(formData);
-        return this.$http.post<CredentialMakeResult>(`${this.makeCredentialsEndpoint}?alias=${registrationAlias}`, body);
+        return this.$http.post<AttestationVerificationSuccess>(`${this.makeCredentialsEndpoint}?alias=${registrationAlias}`, body);
     }
 
 }

--- a/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/types.ts
+++ b/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/types.ts
@@ -2,6 +2,8 @@
     readonly redirectUrl: string;
     // Base 64 encoded credentials
     readonly credentialId: string;
+
+    readonly isPassKey: boolean;
 }
 
 //Incomplete model, we've for now only added what we need

--- a/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/types.ts
+++ b/src/Our.Umbraco.Passless/UI/App_Plugins/UmbracoPassless/BackOffice/types.ts
@@ -5,13 +5,9 @@
 }
 
 //Incomplete model, we've for now only added what we need
-export interface CredentialMakeResult {
-    readonly result: AttestationVerificationSuccess;
-}
-
-//Incomplete model, we've for now only added what we need
 export interface AttestationVerificationSuccess {
     readonly credentialId: string;
+    readonly isPassKey: boolean;
 }
 
 export interface UserCredentials {


### PR DESCRIPTION
Due to a bug with windows hello and passkeys, we should stop persisting credential ID on those logins.

Hence this PR Enforces attestation, as testing has shown that passkey signins return attestation "none" . We use this to determine whether it's a passkey or not. Not sure if more rigid solution exists?